### PR TITLE
Добавил поиск по подстроке + выбор кол-ва книг на странице поисковой выдачи

### DIFF
--- a/src/main/java/ru/mephi/ourbookstore/controller/book/BookController.java
+++ b/src/main/java/ru/mephi/ourbookstore/controller/book/BookController.java
@@ -8,7 +8,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import ru.mephi.ourbookstore.domain.dto.book.*;
 import ru.mephi.ourbookstore.domain.dto.bookPage.BookPageDto;
+import ru.mephi.ourbookstore.mapper.book.BookDtoMapper;
 import ru.mephi.ourbookstore.mapper.book.BookDtoMapperImpl;
+import ru.mephi.ourbookstore.mapper.book.BookModelMapper;
 import ru.mephi.ourbookstore.service.book.BookService;
 
 import java.util.List;
@@ -21,6 +23,7 @@ public class BookController {
 
     final BookService bookService;
     final BookDtoMapperImpl bookDtoMapper;
+    final BookModelMapper bookModelMapper;
 
     @GetMapping("/{bookId}")
     public BookDto getById(@PathVariable long bookId) {
@@ -41,10 +44,8 @@ public class BookController {
     }
 
     @GetMapping("/search")
-    public List<BookDto> search(@RequestBody BookSearchRqDto bookSearchRqDto) {
-        return bookService.search(bookSearchRqDto).stream()
-                .map(bookDtoMapper::objectToDto)
-                .toList();
+    public BookPageDto search(@RequestBody BookSearchRqDto bookSearchRqDto) {
+        return BookDtoMapper.searchResultToPageDto(bookService.search(bookSearchRqDto), bookSearchRqDto.getBookPerPage(), bookModelMapper, bookDtoMapper);
     }
 
     @GetMapping("search/defaults")

--- a/src/main/java/ru/mephi/ourbookstore/domain/dto/book/BookSearchRqDto.java
+++ b/src/main/java/ru/mephi/ourbookstore/domain/dto/book/BookSearchRqDto.java
@@ -11,6 +11,7 @@ import lombok.experimental.FieldDefaults;
 public class BookSearchRqDto {
     String searchText;
     int pageNumber;
+    int bookPerPage;
     String dateOfBirthFrom;
     String dateOfBirthTo;
 }

--- a/src/main/java/ru/mephi/ourbookstore/mapper/book/BookDtoMapper.java
+++ b/src/main/java/ru/mephi/ourbookstore/mapper/book/BookDtoMapper.java
@@ -1,14 +1,16 @@
 package ru.mephi.ourbookstore.mapper.book;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.NullValueMappingStrategy;
+import org.hibernate.search.engine.search.query.SearchResult;
+import org.mapstruct.*;
 import org.springframework.data.domain.Page;
+import ru.mephi.ourbookstore.domain.BookModel;
 import ru.mephi.ourbookstore.domain.dto.book.Book;
 import ru.mephi.ourbookstore.domain.dto.book.BookCreateDto;
 import ru.mephi.ourbookstore.domain.dto.book.BookDto;
 import ru.mephi.ourbookstore.domain.dto.book.BookUpdateDto;
 import ru.mephi.ourbookstore.domain.dto.bookPage.BookPageDto;
+
+import java.util.List;
 
 /**
  * @author Aleksei Iagnenkov (alekseiiagn)
@@ -24,4 +26,14 @@ public interface BookDtoMapper {
 
     @Mapping(source = "content", target = "books")
     BookPageDto objectToPageDto(Page<Book> bookPage);
+
+    @Named("searchResultToPageDto")
+    static BookPageDto searchResultToPageDto(SearchResult<BookModel> search, int bookPerPage, BookModelMapper modelMapper, BookDtoMapper dtoMapper) {
+        List<BookDto> books = search.hits().stream().map(modelMapper::modelToObject).map(dtoMapper::objectToDto).toList();
+        int bookPerPages = (int)search.total().hitCount()/bookPerPage;
+        if (search.total().hitCount()%bookPerPage > 0) {
+            bookPerPages++;
+        }
+        return new BookPageDto(bookPerPages, books);
+    }
 }


### PR DESCRIPTION
Добавил поиск по подстроке (работает как логическое ИЛИ с нечетким поиском, максимальная дистанция которого = 2).
Добавил в BookSearchRqDto поле bookPerPage - количество книжек на 1 странице в выдаче поиска.
Ручка GET "books/search" теперь возвращает не хуе-мое, а BookPageDto.
Например,
РЕКВЕСТ:
{
  "searchText": "ook",
  "bookPerPage": 3,
  "pageNumber": 0,
  "dateOfBirthFrom": null,
  "dateOfBirthTo": null
}

ОТВЕТ:
{
    "totalPages": 1,
    "books": [
        {
            "id": 5,
            "name": "book2",
            "price": 1.0,
            "count": 1,
            "image": null,
            "authors": [
                {
                    "id": "2",
                    "fullName": "Markes Gabriel",
                    "dateOfBirth": "2002-01-01",
                    "country": "Russia",
                    "books": []
                }
            ]
        },
        {
            "id": 4,
            "name": "book1",
            "price": 1.0,
            "count": 1,
            "image": null,
            "authors": [
                {
                    "id": "1",
                    "fullName": "King Stephen",
                    "dateOfBirth": "2000-01-01",
                    "country": "Russia",
                    "books": []
                }
            ]
        },
        {
            "id": 6,
            "name": "book343",
            "price": 1.0,
            "count": 1,
            "image": null,
            "authors": [
                {
                    "id": "2",
                    "fullName": "Markes Gabriel",
                    "dateOfBirth": "2002-01-01",
                    "country": "Russia",
                    "books": []
                }
            ]
        }
    ]
}